### PR TITLE
Update token.mjs

### DIFF
--- a/js/token.mjs
+++ b/js/token.mjs
@@ -105,7 +105,7 @@ async function OnRenderTokenConfig(config, html, context) {
     data.showidle = game.settings.get(MODULENAME, "playIdleAnimations") && !data.separateidle;
     data.hide = !data.spritesheet || isPredefined;
     data.hideaux = !data.spritesheet;
-    const rendered = $(await renderTemplate(`modules/${MODULENAME}/templates/token-settings.hbs`, data)).get(0);
+    const rendered = $(await foundry.applications.handlebars.renderTemplate(`modules/${MODULENAME}/templates/token-settings.hbs`, data)).get(0);
     if (!form.querySelector(".spritesheet-config")) {
       $(form).find("[name='texture.src']").closest(".form-group").after(`<div class="spritesheet-config"></div>`)
     };


### PR DESCRIPTION
Fix for Error: You are accessing the global "renderTemplate" which is now namespaced under foundry.applications.handlebars.renderTemplate Deprecated since Version 13
Backwards-compatible support will be removed in Version 15